### PR TITLE
Fixed persistence issue on refresh

### DIFF
--- a/client/src/pages/CourseList.tsx
+++ b/client/src/pages/CourseList.tsx
@@ -76,7 +76,7 @@ const CourseList: React.FC = () => {
     }`;
     window.history.pushState({}, "", url);
 
-    // getCourses(currentPage, currSearchQuery);
+    getCourses(currentPage, currSearchQuery);
   }, [currentPage, currSearchQuery]);
 
   // should trigger this useeffect when the current search query changes


### PR DESCRIPTION
This fixes the following bug:

When the page number is something other than 1, the page will display the courses of page 1 after a refresh.

![image](https://github.com/user-attachments/assets/7d5f9e61-d63f-4605-815a-b1158bbbcb16)
In the above, we see the intended 8th page.
![image](https://github.com/user-attachments/assets/87bb058c-d411-455a-ae31-4bd20b06b564)
Now, the page has been refreshed. Note the navigation at the bottom still shows page 8, but the content now shows page 1's content.


The only change I made was uncommenting a call to `GetCourses()`. I'm sure that was commented out for a reason, but after messing around with the site for a bit I didn't see any problems and it fixed the issue so here's my PR.