### PR TITLE
Corrected race condition in CourseList

### DIFF
--- a/client/src/modules/contributors.js
+++ b/client/src/modules/contributors.js
@@ -1,3 +1,3 @@
-const contributors = ['AmBha21', 'kylechi05']
+const contributors = ['AmBha21', 'kylechi05', 'chrisnair']
 
 export default contributors;


### PR DESCRIPTION
`CourseList.tsx` data fetching was being handled in more than one spot, causing race condition. Also I added `popstate` handler to fix the back arrow issue. I realized the uncommenting of the call to `getCourses()` fixed my issue by pure coincidence, and it actually was just randomly working. The issue was that data was being fetched (asynchronously) multiple times on a page refresh. This led to the data of the proper page loading, then the data for page one loading right after it. If page one loaded first, then the proper page would load, and the behavior would appear correct. Now, all data fetching on page load has been consolidated to one `useEffect()` call. 

See here:
https://github.com/chrisnair/uigrades/blob/fa2be6a7934e217e2b8371a4c34a0c25e1e52506/client/src/pages/CourseList.tsx#L96-L131
Now, there is only one `fetch` call on any sort of page load or change to `currentPage` or `currentSearchQuery`, instead of multiple, which caused the race condition. 
I also added a `popstate` handler, which closes #22 .

https://github.com/chrisnair/uigrades/blob/fa2be6a7934e217e2b8371a4c34a0c25e1e52506/client/src/pages/CourseList.tsx#L81-L93

I needed to get all the data from the URL both in the event of  a `popstate` and on page load, so I moved that logic to a new function, `parseUrlParams()`.

https://github.com/chrisnair/uigrades/blob/fa2be6a7934e217e2b8371a4c34a0c25e1e52506/client/src/pages/CourseList.tsx#L60-L67

I also cheekily added myself to the contributors cause this was cooler than just uncommenting something. I won't be offended at all if you remove me though it's cool enough being on the github.